### PR TITLE
you can now search for ingredients in the recipe search bar

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -15,6 +15,9 @@ class Recipe < ApplicationRecord
   include PgSearch::Model
   pg_search_scope :search_by_name_and_description,
     against: [ :name, :description ],
+    associated_against: {
+      ingredients: [ :name ]
+    },
     using: {
       tsearch: { prefix: true }
     }


### PR DESCRIPTION
I have changed the pg search on the recipes page so that you can now search for ingredients of the recipe and recipe will come up.