### PR TITLE
align recipe show page image

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -26,3 +26,9 @@
   padding-top: 40px;
 }
 // body recipe show page
+.center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 50%;
+}

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,5 +1,5 @@
 
-<div class="show-page-container">
+<div class="show-page-container d-flex justify-content-center">
   <div class="banner-show"></div>
     <%= image_tag("cake.jpg", width: "400px", heigth: '200px', alt: "an image of a recipe")%>
   </div>


### PR DESCRIPTION
The image on show page is now centered.

Before:
![image](https://user-images.githubusercontent.com/33075306/143579438-d0ea69ab-cf0c-4577-a2e3-4930ef3a0298.png)

After:
![image](https://user-images.githubusercontent.com/33075306/143579399-05e38711-22ff-4eb1-af1a-7684e8005cd2.png)
