### PR TITLE
extra functionality to add new days to planner

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -74,12 +74,12 @@ input[type="radio"]:checked + .form-check-label{
 .btn-myplanner {
   border: solid 1px grey;
   border-radius: 10px;
-  margin-bottom: 20px;
-  padding:7px 50px;
-  margin-top: 20px;
-  color: black!important;
+  margin: 20px 10px;
+  padding: 7px 20px!important;
+  color: black;
   font-size: 14px;
   opacity: 0.7!important;
+  display: inline;
 }
 
 .btn-myplanner:hover {
@@ -97,6 +97,7 @@ input[type="radio"]:checked + .form-check-label{
   padding: 6px 50px;
   border: none;
   border-radius: 10px;
+  font-size: 16px;
 }
 
 .general-button-green {

--- a/app/assets/stylesheets/components/_planner.scss
+++ b/app/assets/stylesheets/components/_planner.scss
@@ -1,7 +1,7 @@
 .planner-day {
   width: 100%;
   padding: 15px 30px;
-  margin-top: 30px;
+  margin-top: 20px;
   text-align: center;
   border-radius: 20px;
   border: 1px solid black;
@@ -20,7 +20,7 @@
 
 
 .content-planner {
-  margin: 30px;
+  margin: 15px 30px;
 }
 
 .form-control {

--- a/app/controllers/planned_recipes_controller.rb
+++ b/app/controllers/planned_recipes_controller.rb
@@ -36,19 +36,17 @@ class PlannedRecipesController < ApplicationController
 
   def planner
     days = params[:days]
-    puts days
-    today = Date.today
+    @planner_recipes = PlannedRecipe.order(:date)
+    @future_meals = @planner_recipes.select { |meal| meal.date > Date.today }
+    today = @future_meals.count < 1 ? Date.today : PlannedRecipe.order(:date).last.date
     i = 1
     days.to_i.times do
-      if PlannedRecipe.create!(date: today + i, user: current_user, recipe: Recipe.last)
-        today += 1.day
-      else
-        flash[:alert] = 'You already have a plan for that day!'
-        redirect_to 'planned_recipes_planner_path'
-      end
+      PlannedRecipe.create!(date: today + i, user: current_user, recipe: Recipe.last)
+      today += 1.day
     end
     @planner_recipes = PlannedRecipe.order(:date)
     @all_recipes = Recipe.where(creator: current_user)
+    @future_meals = @planner_recipes.select { |meal| meal.date > Date.today }
   end
 
   def shopping_list
@@ -69,7 +67,6 @@ class PlannedRecipesController < ApplicationController
       @fridge_items[item.ingredient.name] = 1
     end
     @shopping_list.each do |shopping, _vol|
-    # # @fridge_items.each do |item, num|
       if @fridge_items.has_key?(shopping)
         @shopping_list[shopping] -= @fridge_items[shopping]
       end

--- a/app/views/planned_recipes/planner.html.erb
+++ b/app/views/planned_recipes/planner.html.erb
@@ -1,6 +1,7 @@
 <div class="pages-header">
 <h2 class="m-5 text-center">My Planner</h2>
 </div>
+
 <div class="content-planner">
   <div class="planner-card">
     <% @planner_recipes.each do |recipe| %>
@@ -17,6 +18,41 @@
   </div>
 </div>
 
-<div class="text-center text-small">
-  <p><small><%= link_to "Generate shopping list!", shopping_list_planned_recipes_path, class: "btn-myplanner" %><small></p>
+<% if @future_meals.count > 0 %>
+  <div class="text-center text-small">
+    <p><small><%= link_to "Shopping list", shopping_list_planned_recipes_path, class: "btn-myplanner general-button-blue text-white" %>
+    <button type="button" class="btn-myplanner general-button-green text-white" data-toggle="modal" data-target="#exampleModal">
+      Add days
+    <small></button>
+  </div>
+
+<div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">How many days?</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <form action="/planned_recipes/planner" method="post" class="recipe-form-home mt-2">
+          <div><input type="integer" name="days" class="search-bar-home mb-1 px-5 py-2 text-center lead" placeholder="e.g. 5"></div>
+          <div class="text-center"><input type="submit", class="btn-myplanner general-button-blue text-white"></div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
+
+
+  </div>
+<% else %>
+  <div class="mb-4 text-center mx-5"><h4 class="text-center align-items-start">How many meals would you like to plan?</h4></div>
+  <form action="/planned_recipes/planner" method="post" class="recipe-form-home mt-2 mx-3">
+    <div class="container">
+      <div><input type="integer" name="days" class="search-bar-home mb-1 px-5 py-2 text-small text-center" placeholder="e.g. 5"></div>
+      <div class="text-center"><input value="Go!", type="submit", class="btn-myplanner"></div>
+    </div>
+  </form>
+<% end %>


### PR DESCRIPTION
A few upgrades on the planner page:
- if there's nothing planned, it gives you a form to generate a new planner
- otherwise there are two links at the bottom of the page, one for the shopping list, and one to add additional days
- adding days gives a pop-up, and now works so that it will add on to the end of the current planner

![image](https://user-images.githubusercontent.com/63204926/143776292-83a49eec-3f1d-4226-a604-b48885063872.png)
![image](https://user-images.githubusercontent.com/63204926/143776334-1a6cf4a0-d3f8-4c44-89fd-1417a74b0e49.png)
![image](https://user-images.githubusercontent.com/63204926/143776359-a3c75ace-5822-421c-b3c9-b5b88e441b10.png)

