### PR TITLE
making the planner button clearer

### DIFF
--- a/app/views/planned_recipes/planner.html.erb
+++ b/app/views/planned_recipes/planner.html.erb
@@ -20,7 +20,8 @@
 
 <% if @future_meals.count > 0 %>
   <div class="text-center text-small">
-    <p><small><%= link_to "Shopping list", shopping_list_planned_recipes_path, class: "btn-myplanner general-button-blue text-white" %>
+    <small><%= link_to "Generate Shopping list", shopping_list_planned_recipes_path, class: "btn-myplanner general-button-blue text-white" %>
+    <br>
     <button type="button" class="btn-myplanner general-button-green text-white" data-toggle="modal" data-target="#exampleModal">
       Add days
     <small></button>


### PR DESCRIPTION
Making the generate shopping list button clearer:
![image](https://user-images.githubusercontent.com/33075306/144280634-aef0e295-dcd2-41eb-96fa-6d1b66a56452.png)
